### PR TITLE
Hide the navbar for showcase apps - hit with #nochrome

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -120,3 +120,34 @@ nav {
   font-size: 16px;
   line-height: 20px;
 }
+
+body.nochrome .navbar {
+  display: none;
+}
+
+body.nochrome {
+  padding-top: 0;
+}
+
+body.nochrome .toolbar {
+  top: 0;
+  margin-top: 0;
+}
+
+body.nochrome .navigation {
+  top: 0;
+}
+
+body.nochrome .main-wrapper {
+  margin-top: 0;
+}
+
+body.nochrome .main-wrapper .main .toolbar {
+  top: 0;
+}
+
+@media screen and (min-width: 1024px) {
+  .navigation {
+    height: calc(100vh - 0);
+  }
+}

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -52,7 +52,16 @@ function createSwitchItem(block, blockSwitch) {
 	return {'item': item, 'content': content};
 }
 
-$(addBlockSwitches);    
+$(addBlockSwitches);
+
+
+Zepto(function($){
+	if (document.location.hash.indexOf("nochrome") > -1) {
+		// Hide the navbar for showcase apps (#nochrome)
+		$('body').addClass('nochrome');
+	}
+})
+
 </script>
 
 


### PR DESCRIPTION
http://localhost:5252/

<img width="1091" alt="screen shot 2018-07-02 at 15 14 31" src="https://user-images.githubusercontent.com/4467/42169099-bb2272a6-7e0a-11e8-8d1b-f75e5aa9817a.png">

http://localhost:5252/#nochrome

<img width="1102" alt="screen shot 2018-07-02 at 15 14 15" src="https://user-images.githubusercontent.com/4467/42169109-c0700110-7e0a-11e8-8f72-6aab79e95780.png">
