### PR TITLE
Get param to hide the header

### DIFF
--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -7,6 +7,7 @@
 <script src="https://code.jquery.com/jquery-1.9.1.min.js" integrity="sha256-wS9gmOZBqsqWxgIVgA8Y9WcQOa7PgSIX+rPA0VL2rbQ=" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js" integrity="sha384-Nud2SriDt2fZ+u85IBC48Yn9p+l4AGlapnX1EGA2KrnZjYJx8sxKnw/CIxc1wU1B" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-url/2.5.3/url.js"></script>
 <script>
 function addBlockSwitches() {
 	$('.primary').each(function() {
@@ -54,14 +55,12 @@ function createSwitchItem(block, blockSwitch) {
 
 $(addBlockSwitches);
 
-
 Zepto(function($){
-	if (document.location.hash.indexOf("nochrome") > -1) {
+	if (url('?header') === 'false') {
 		// Hide the navbar for showcase apps (#nochrome)
 		$('body').addClass('nochrome');
 	}
 })
-
 </script>
 
 


### PR DESCRIPTION
Follow-on from https://github.com/aerogear/antora-ui/pull/11

Re-jigged to use a `GET` parameter instead.

http://localhost:5252/

<img width="1091" alt="screen shot 2018-07-02 at 15 14 31" src="https://user-images.githubusercontent.com/4467/42169099-bb2272a6-7e0a-11e8-8d1b-f75e5aa9817a.png">

http://localhost:5252/?header=false

<img width="1102" alt="screen shot 2018-07-02 at 15 14 15" src="https://user-images.githubusercontent.com/4467/42169109-c0700110-7e0a-11e8-8f72-6aab79e95780.png">
